### PR TITLE
ci: delay main-to-next sync until version merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      versionPullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}
 
     steps:
       - name: Generate App Token
@@ -186,7 +187,7 @@ jobs:
           PLATE_RELEASE_CHANNEL: ${{ steps.release_channel.outputs.channel }}
 
       - name: 🏷️ Push package tags
-        if: ${{ steps.changesets.outputs.published == 'true' }}
+        if: ${{ github.repository == 'udecode/plate' && steps.changesets.outputs.published == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.API_TOKEN_GITHUB || secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
@@ -226,7 +227,7 @@ jobs:
 
       - name: 📝 Generate raw release notes
         id: raw-notes
-        if: ${{ steps.changesets.outputs.published == 'true' }}
+        if: ${{ github.repository == 'udecode/plate' && steps.changesets.outputs.published == 'true' }}
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: node tooling/scripts/release-notes.mjs
@@ -272,7 +273,7 @@ jobs:
           fi
 
       - name: 📝 Create GitHub Release
-        if: ${{ steps.changesets.outputs.published == 'true' }}
+        if: ${{ github.repository == 'udecode/plate' && steps.changesets.outputs.published == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.API_TOKEN_GITHUB || secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.raw-notes.outputs.version }}
@@ -332,7 +333,7 @@ jobs:
     name: Sync registry and templates after publish
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.result == 'success' && needs.release.outputs.published == 'true' && github.ref_name == 'main' }}
+    if: ${{ needs.release.result == 'success' && needs.release.outputs.published == 'true' && github.ref_name == 'main' && github.repository == 'udecode/plate' }}
     permissions:
       contents: write
       pull-requests: write
@@ -525,7 +526,7 @@ jobs:
     needs:
       - release
       - sync-release-artifacts
-    if: ${{ always() && needs.release.result == 'success' && (needs.sync-release-artifacts.result == 'success' || needs.sync-release-artifacts.result == 'skipped') && github.ref_name == 'main' }}
+    if: ${{ always() && needs.release.result == 'success' && (needs.sync-release-artifacts.result == 'success' || needs.sync-release-artifacts.result == 'skipped') && github.ref_name == 'main' && needs.release.outputs.versionPullRequestNumber == '' }}
     permissions:
       contents: write
       pull-requests: write

--- a/tooling/scripts/release-packages.mjs
+++ b/tooling/scripts/release-packages.mjs
@@ -63,12 +63,8 @@ export function getReleasePlan(channel) {
   throw new Error(`Unsupported release channel: ${channel}`);
 }
 
-export function assertPublishEnabled({ env = process.env } = {}) {
-  if (env.PLATE_DISABLE_PUBLISH === 'true') {
-    throw new Error(
-      'Package publishing is disabled for this repository. Version PR testing can run, but npm publish is blocked.'
-    );
-  }
+export function isPublishDisabled({ env = process.env } = {}) {
+  return env.PLATE_DISABLE_PUBLISH === 'true';
 }
 
 function runBetaRelease() {
@@ -128,7 +124,12 @@ function isMainModule() {
 
 if (isMainModule()) {
   try {
-    assertPublishEnabled();
+    if (isPublishDisabled()) {
+      console.log(
+        'Package publishing is disabled for this repository. Skipping npm publish for Version PR workflow testing.'
+      );
+      process.exit(0);
+    }
 
     const channel = resolveReleaseChannel();
 

--- a/tooling/scripts/release-workflow.test.mjs
+++ b/tooling/scripts/release-workflow.test.mjs
@@ -12,8 +12,8 @@ import {
   resolvePackageManifestForMainToNextSync,
 } from './release-branch-prs.mjs';
 import {
-  assertPublishEnabled,
   getReleasePlan,
+  isPublishDisabled,
   resolveReleaseChannel,
 } from './release-packages.mjs';
 
@@ -71,9 +71,17 @@ test('release workflow uses the pruned GitHub Release path', async () => {
     workflow,
     /PLATE_RELEASE_CHANNEL:\s*\$\{\{ steps\.release_channel\.outputs\.channel \}\}/
   );
+  assert.match(
+    workflow,
+    /versionPullRequestNumber:\s*\$\{\{ steps\.changesets\.outputs\.pullRequestNumber \}\}/
+  );
   assert.match(workflow, /createGithubReleases:\s*false/);
   assert.match(workflow, /version:\s*pnpm ci:version/);
   assert.match(workflow, /publish:\s*pnpm ci:release/);
+  assert.match(
+    workflow,
+    /github\.repository == 'udecode\/plate' && steps\.changesets\.outputs\.published == 'true'/
+  );
   assert.match(workflow, /node tooling\/scripts\/published-package-tags\.mjs/);
   assert.match(workflow, /refs\/tags\/\$\{tag\}:refs\/tags\/\$\{tag\}/);
   assert.match(
@@ -102,7 +110,7 @@ test('release workflow uses the pruned GitHub Release path', async () => {
   assert.match(workflow, /sync-release-artifacts:/);
   assert.match(
     workflow,
-    /needs\.release\.outputs\.published == 'true' && github\.ref_name == 'main'/
+    /needs\.release\.outputs\.published == 'true' && github\.ref_name == 'main' && github\.repository == 'udecode\/plate'/
   );
   assert.match(workflow, /sync-main-to-next:/);
   assert.match(
@@ -111,7 +119,7 @@ test('release workflow uses the pruned GitHub Release path', async () => {
   );
   assert.match(
     workflow,
-    /always\(\) && needs\.release\.result == 'success' && \(needs\.sync-release-artifacts\.result == 'success' \|\| needs\.sync-release-artifacts\.result == 'skipped'\) && github\.ref_name == 'main'/
+    /always\(\) && needs\.release\.result == 'success' && \(needs\.sync-release-artifacts\.result == 'success' \|\| needs\.sync-release-artifacts\.result == 'skipped'\) && github\.ref_name == 'main' && needs\.release\.outputs\.versionPullRequestNumber == ''/
   );
   assert.doesNotMatch(
     workflow,
@@ -370,12 +378,17 @@ test('beta package release uses an explicit npm beta tag', async () => {
     hidePreStateForPublish: true,
     publish: ['pnpm', ['changeset', 'publish', '--tag', 'beta']],
   });
-  assert.doesNotThrow(() =>
-    assertPublishEnabled({ env: { PLATE_DISABLE_PUBLISH: 'false' } })
+  assert.equal(
+    isPublishDisabled({ env: { PLATE_DISABLE_PUBLISH: 'false' } }),
+    false
   );
-  assert.throws(
-    () => assertPublishEnabled({ env: { PLATE_DISABLE_PUBLISH: 'true' } }),
-    /Package publishing is disabled/
+  assert.equal(
+    isPublishDisabled({ env: { PLATE_DISABLE_PUBLISH: 'true' } }),
+    true
+  );
+  assert.match(
+    releasePackages,
+    /Skipping npm publish for Version PR workflow testing/
   );
   assert.match(releasePackages, /pre\.json\.beta-publish-backup/);
   assert.match(


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 #17 carried the raw changeset before #16 release metadata landed | ➖ N/A |
| Verified | 🟢 `node --test tooling/scripts/release-workflow.test.mjs` and `pnpm check` | ➖ N/A |

**✅ Outcome**
Closed stale sync PR #17 and updated release automation so `main -> next` sync waits until no Version Packages PR was created in the current release run. Fork publish-disabled runs now noop successfully, allowing the post-Version-PR sync test to continue without npm publish.

**⚠️ Caveat**
The fork still needs `RELEASE_VERSION_PR_TEST=true` for the release workflow to run. That is intentional.

**🏗️ Design**
The release job exposes `versionPullRequestNumber`; `sync-main-to-next` skips when that output is non-empty, then runs on the later Version PR merge run. Publish-only release artifacts remain limited to `udecode/plate`.

**🧪 Verified**
- `gh pr close 17 --repo felixfeng33/plate`
- `PLATE_DISABLE_PUBLISH=true node tooling/scripts/release-packages.mjs`
- `node --test tooling/scripts/release-workflow.test.mjs`
- `pnpm check`
- autoreview attempted with Codex and failed on local CLI config; Claude review produced one finding, rejected because fork sync is required for this test path and non-test forks are already gated by `RELEASE_VERSION_PR_TEST`.