### PR TITLE
ci: preserve changelog order in main sync

### DIFF
--- a/tooling/scripts/release-branch-prs.mjs
+++ b/tooling/scripts/release-branch-prs.mjs
@@ -190,55 +190,6 @@ function parseSemver(version) {
   };
 }
 
-function comparePrereleaseDesc(a, b) {
-  const aParts = a.split('.');
-  const bParts = b.split('.');
-  const length = Math.max(aParts.length, bParts.length);
-
-  for (let index = 0; index < length; index++) {
-    const aPart = aParts[index];
-    const bPart = bParts[index];
-
-    if (aPart === bPart) continue;
-    if (aPart === undefined) return 1;
-    if (bPart === undefined) return -1;
-
-    const aNumber = Number(aPart);
-    const bNumber = Number(bPart);
-    const bothNumeric = Number.isInteger(aNumber) && Number.isInteger(bNumber);
-
-    if (bothNumeric) return bNumber - aNumber;
-
-    return bPart.localeCompare(aPart);
-  }
-
-  return 0;
-}
-
-function compareChangelogSections(a, b) {
-  const aSemver = parseSemver(a.version);
-  const bSemver = parseSemver(b.version);
-
-  if (aSemver && bSemver) {
-    for (const key of ['major', 'minor', 'patch']) {
-      if (aSemver[key] !== bSemver[key]) return bSemver[key] - aSemver[key];
-    }
-
-    if (aSemver.pre && !bSemver.pre) return -1;
-    if (!aSemver.pre && bSemver.pre) return 1;
-    if (aSemver.pre && bSemver.pre) {
-      return comparePrereleaseDesc(aSemver.pre, bSemver.pre);
-    }
-
-    return 0;
-  }
-
-  if (aSemver) return -1;
-  if (bSemver) return 1;
-
-  return a.index - b.index;
-}
-
 function parseChangelog(content) {
   const normalized = content.replace(/\r\n/g, '\n');
   const sectionMatches = [...normalized.matchAll(/^##\s+(.+?)\s*$/gm)];
@@ -269,31 +220,69 @@ function parseChangelog(content) {
   return { header, sections };
 }
 
-export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
-  const oursChangelog = parseChangelog(ours);
-  const theirsChangelog = parseChangelog(theirs);
-  const sectionsByVersion = new Map();
+function isStableChangelogSection(section) {
+  const version = parseSemver(section.version);
 
-  for (const section of oursChangelog.sections) {
-    sectionsByVersion.set(section.version, { ...section, source: 'ours' });
-  }
+  return !!version && !version.pre;
+}
 
-  for (const section of theirsChangelog.sections) {
-    const existing = sectionsByVersion.get(section.version);
+function collectStableChangelogInsertions({ oursVersions, theirsSections }) {
+  const sectionsByAnchorVersion = new Map();
+  const pendingSections = [];
+  for (const section of theirsSections) {
+    if (!isStableChangelogSection(section)) continue;
 
-    if (!existing) {
-      sectionsByVersion.set(section.version, { ...section, source: 'theirs' });
+    if (!oursVersions.has(section.version)) {
+      pendingSections.push(section);
       continue;
     }
 
-    if (!parseSemver(section.version)?.pre) {
-      sectionsByVersion.set(section.version, { ...section, source: 'theirs' });
+    if (pendingSections.length > 0) {
+      sectionsByAnchorVersion.set(section.version, [...pendingSections]);
+      pendingSections.length = 0;
     }
   }
 
-  const sections = [...sectionsByVersion.values()].sort(
-    compareChangelogSections
+  return {
+    sectionsByAnchorVersion,
+    trailingSections: pendingSections,
+  };
+}
+
+export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
+  const oursChangelog = parseChangelog(ours);
+  const theirsChangelog = parseChangelog(theirs);
+  const oursVersions = new Set(
+    oursChangelog.sections.map((section) => section.version)
   );
+  const theirsByVersion = new Map(
+    theirsChangelog.sections.map((section) => [section.version, section])
+  );
+  const stableInsertions = collectStableChangelogInsertions({
+    oursVersions,
+    theirsSections: theirsChangelog.sections,
+  });
+  const sections = [];
+
+  for (const section of oursChangelog.sections) {
+    const sectionsToInsert = stableInsertions.sectionsByAnchorVersion.get(
+      section.version
+    );
+    const theirsSection = theirsByVersion.get(section.version);
+
+    if (sectionsToInsert) {
+      sections.push(...sectionsToInsert);
+    }
+
+    sections.push(
+      theirsSection && isStableChangelogSection(section)
+        ? theirsSection
+        : section
+    );
+  }
+
+  sections.push(...stableInsertions.trailingSections);
+
   const header = oursChangelog.header || theirsChangelog.header;
 
   return `${header}\n\n${sections.map((section) => section.raw).join('\n\n')}\n`;

--- a/tooling/scripts/release-workflow.test.mjs
+++ b/tooling/scripts/release-workflow.test.mjs
@@ -239,6 +239,18 @@ test('main to next sync keeps beta changelog sections above stable history', () 
       '',
       '- Existing stable patch.',
       '',
+      '## 1.0.0',
+      '',
+      '### Major Changes',
+      '',
+      '- Existing old stable release.',
+      '',
+      '## 1.0.0-next.61',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing old prerelease.',
+      '',
     ].join('\n'),
     theirs: [
       '# @platejs/core',
@@ -261,16 +273,174 @@ test('main to next sync keeps beta changelog sections above stable history', () 
       '',
       '- Existing stable patch from main.',
       '',
+      '## 1.0.0',
+      '',
+      '### Major Changes',
+      '',
+      '- Existing old stable release from main.',
+      '',
+      '## 1.0.0-next.61',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing old prerelease.',
+      '',
     ].join('\n'),
   });
 
   assert.equal(
     [...resolved.matchAll(/^##\s+(.+)$/gm)].map((match) => match[1]).join(','),
-    '54.0.0-beta.1,54.0.0-beta.0,53.1.8,53.1.7,53.1.2'
+    '54.0.0-beta.1,54.0.0-beta.0,53.1.8,53.1.7,53.1.2,1.0.0,1.0.0-next.61'
   );
   assert.match(resolved, /- Main patch\./);
   assert.match(resolved, /- Existing stable patch from main\./);
+  assert.ok(
+    resolved.indexOf('## 1.0.0\n') < resolved.indexOf('## 1.0.0-next.61')
+  );
+  assert.match(resolved, /- Existing old stable release from main\./);
   assert.doesNotMatch(resolved, /<<<<<<<|=======|>>>>>>>/);
+});
+
+test('main to next sync inserts stable changelog sections between existing anchors', () => {
+  const resolved = mergeChangelogsForMainToNextSync({
+    ours: [
+      '# @platejs/core',
+      '',
+      '## 54.0.0-beta.1',
+      '',
+      '### Minor Changes',
+      '',
+      '- Beta minor.',
+      '',
+      '## 53.1.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing synced stable patch.',
+      '',
+      '## 53.1.2',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing older stable patch.',
+      '',
+    ].join('\n'),
+    theirs: [
+      '# @platejs/core',
+      '',
+      '## 53.1.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing synced stable patch from main.',
+      '',
+      '## 53.1.6',
+      '',
+      '### Patch Changes',
+      '',
+      '- Main patch released between sync anchors.',
+      '',
+      '## 53.1.2',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing older stable patch from main.',
+      '',
+    ].join('\n'),
+  });
+
+  assert.equal(
+    [...resolved.matchAll(/^##\s+(.+)$/gm)].map((match) => match[1]).join(','),
+    '54.0.0-beta.1,53.1.8,53.1.6,53.1.2'
+  );
+  assert.match(resolved, /- Main patch released between sync anchors\./);
+  assert.match(resolved, /- Existing synced stable patch from main\./);
+  assert.match(resolved, /- Existing older stable patch from main\./);
+});
+
+test('main to next sync appends stable changelog sections after beta-only history', () => {
+  const resolved = mergeChangelogsForMainToNextSync({
+    ours: [
+      '# @platejs/core',
+      '',
+      '## 54.0.0-beta.1',
+      '',
+      '### Minor Changes',
+      '',
+      '- Beta minor.',
+      '',
+      '## 54.0.0-beta.0',
+      '',
+      '### Major Changes',
+      '',
+      '- Beta major.',
+      '',
+    ].join('\n'),
+    theirs: [
+      '# @platejs/core',
+      '',
+      '## 53.1.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- Main patch.',
+      '',
+      '## 53.1.7',
+      '',
+      '### Patch Changes',
+      '',
+      '- Previous main patch.',
+      '',
+    ].join('\n'),
+  });
+
+  assert.equal(
+    [...resolved.matchAll(/^##\s+(.+)$/gm)].map((match) => match[1]).join(','),
+    '54.0.0-beta.1,54.0.0-beta.0,53.1.8,53.1.7'
+  );
+});
+
+test('main to next sync keeps stable sections after the last matched anchor', () => {
+  const resolved = mergeChangelogsForMainToNextSync({
+    ours: [
+      '# @platejs/core',
+      '',
+      '## 54.0.0-beta.1',
+      '',
+      '### Minor Changes',
+      '',
+      '- Beta minor.',
+      '',
+      '## 53.1.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing synced stable patch.',
+      '',
+    ].join('\n'),
+    theirs: [
+      '# @platejs/core',
+      '',
+      '## 53.1.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- Existing synced stable patch from main.',
+      '',
+      '## 53.1.7',
+      '',
+      '### Patch Changes',
+      '',
+      '- Main patch after the final shared anchor.',
+      '',
+    ].join('\n'),
+  });
+
+  assert.equal(
+    [...resolved.matchAll(/^##\s+(.+)$/gm)].map((match) => match[1]).join(','),
+    '54.0.0-beta.1,53.1.8,53.1.7'
+  );
+  assert.match(resolved, /- Main patch after the final shared anchor\./);
 });
 
 test('auto-retarget workflow moves non-patch changesets from main to next', async () => {


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 #19 moved the old `1.0.0` changelog section below `1.0.0-next.61` | ➖ N/A |
| Verified | 🟢 `node --test tooling/scripts/release-workflow.test.mjs`, real main/next resolver simulation, `pnpm check`, autoreview clean | ➖ N/A |

**✅ Outcome**
Change the main-to-next changelog resolver from global semver sorting to position-preserving insertion. `next` keeps its existing changelog order; main-only stable sections are inserted before the next stable anchor or appended when no anchor exists.

**⚠️ Caveat**
This PR only fixes the resolver. The existing #19 sync PR needs the workflow to rerun after this lands so `sync/main-to-next` is regenerated.

**🏗️ Design**
Stable sections from `main` remain authoritative when the same version exists on both branches. Beta/prerelease sections from `next` remain untouched.

**🧪 Verified**
- `node --test tooling/scripts/release-workflow.test.mjs`
- real `felix/main` + `felix/next` resolver simulation: beta top, `53.1.9` inserted, `1.0.0` remains before `1.0.0-next.61`, no conflict markers
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine claude ...` clean
- `pnpm check`