### PR TITLE
test: add second patch release flow changeset

### DIFF
--- a/.changeset/test-patch-release-flow-2.md
+++ b/.changeset/test-patch-release-flow-2.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Test second patch release PR routing.


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | 🟢 `pnpm check` | ➖ N/A |

**✅ Outcome**
Adds a second patch changeset test PR against `main` so the stable patch release and downstream main-to-next sync path can be re-verified.

**⚠️ Caveat**
This is intentionally a fork release-flow test PR, not a product change.

**🏗️ Design**
Uses a patch changeset for `@platejs/core` on `main`; it should stay on the latest track and must not be retargeted to `next`.

**🧪 Verified**
`pnpm check` passed locally.