### PR TITLE
test: add basic-nodes patch release flow changeset

### DIFF
--- a/.changeset/test-basic-nodes-patch-release-flow.md
+++ b/.changeset/test-basic-nodes-patch-release-flow.md
@@ -1,0 +1,5 @@
+---
+"@platejs/basic-nodes": patch
+---
+
+Test basic-nodes patch release conflict sync.


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | 🟢 `pnpm check` | ➖ N/A |

**✅ Outcome**
Adds a patch changeset for `@platejs/basic-nodes` against `main` so the stable patch release can be synced into `next`, where `basic-nodes` is already on the beta track.

**⚠️ Caveat**
This is intentionally a fork release-flow conflict test PR, not a product change.

**🏗️ Design**
Uses the same package that already has a beta Version PR on `next`, so the later main-to-next sync should exercise package version and changelog conflict handling.

**🧪 Verified**
`pnpm check` passed locally.