### PR TITLE
test: add core major release flow changeset

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -59,7 +59,5 @@
     "@platejs/utils": "53.1.2",
     "@platejs/yjs": "53.0.0"
   },
-  "changesets": [
-    "test-minor-release-flow"
-  ]
+  "changesets": ["test-minor-release-flow"]
 }

--- a/.changeset/test-core-major-release-flow.md
+++ b/.changeset/test-core-major-release-flow.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": major
+---
+
+Test core major release PR routing.


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | 🟢 `pnpm check` | ➖ N/A |

**✅ Outcome**
Adds a major changeset for `@platejs/core` on `next` so the beta release path can verify core major versioning.

**⚠️ Caveat**
This is intentionally a fork release-flow test PR, not a product change. It also formats `.changeset/pre.json` because the current `next` base fails local `pnpm check` without that formatting fix.

**🏗️ Design**
Uses `major` because `minor` is forbidden for core packages. The PR is based on `next` to avoid polluted diffs after auto-retarget.

**🧪 Verified**
`pnpm check` passed locally on the next-based branch.