### PR TITLE
chore: verify main-to-next sync metadata

### DIFF
--- a/.github/workflows/verify-main-to-next-sync.yml
+++ b/.github/workflows/verify-main-to-next-sync.yml
@@ -1,0 +1,35 @@
+name: Verify main-to-next sync
+
+on:
+  pull_request:
+    branches:
+      - next
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release-metadata:
+    name: Verify release metadata resolution
+    if: ${{ github.event.pull_request.head.ref == 'sync/main-to-next' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sync branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify main-to-next metadata merge
+        run: node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync

--- a/docs/plans/2026-06-16-sync-pr-observability.md
+++ b/docs/plans/2026-06-16-sync-pr-observability.md
@@ -1,0 +1,254 @@
+# sync pr observability
+
+Objective:
+Make main-to-next sync PRs auditable: PR body shows resolver decisions and CI verifies metadata resolution safety.
+
+Goal plan:
+docs/plans/2026-06-16-sync-pr-observability.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- none
+
+Task source:
+- type: chat request
+- id / link: local thread
+- title: Add observability for main -> next sync resolver
+- acceptance criteria: sync PR body names resolver decisions; a sync PR check verifies no conflict markers, beta versions preserved, stable changelogs inserted, and package manifests avoid third-state edits.
+
+Completion threshold:
+- `tooling/scripts/release-branch-prs.mjs` records main -> next resolver decisions and can verify a sync merge commit.
+- Sync PR body includes the resolver report.
+- A pull_request workflow runs the verifier for `sync/main-to-next` PRs into `next`.
+- Unit tests cover the report and verifier behavior.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-sync-pr-observability.md` passes.
+
+Verification surface:
+- `node --test tooling/scripts/release-workflow.test.mjs`
+- `pnpm lint:fix`
+- `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-sync-pr-observability.md`
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: `tooling/scripts/release-branch-prs.mjs`, `.github/workflows/release.yml`, `.github/workflows/verify-changesets.yml`, current sync PR evidence.
+- Allowed edit scope: release branch PR tooling, release workflow tests, sync verification workflow, goal plan.
+- Browser surface: N/A, release automation only.
+- Tracker sync: N/A, no issue tracker requested.
+- Non-goals: no npm publish, no release PR merge, no beta docs switcher work.
+
+Output budget strategy:
+- Use scoped `sed`/`rg` reads only for release tooling, workflows, and relevant docs/solutions. Cap command output and avoid broad history dumps.
+
+Blocked condition:
+- Blocked only if local tests expose unrelated repo-wide install corruption that persists after the documented reinstall retry, or if GitHub workflow semantics require a remote-only secret/path not visible from repo source.
+
+Task state:
+- task_type: release automation tooling
+- task_complexity: medium
+- current_phase: implementation
+- current_phase_status: in_progress
+- next_phase: verification
+- goal_status: active
+
+Current verdict:
+- verdict: implement
+- confidence: medium-high
+- next owner: task
+- reason: Current resolver works but needs audit output and an independent PR check before it deserves trust.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-sync-pr-observability.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | read `autogoal`, `task`, and `autoreview` skill instructions relevant to this task |
+| Active goal checked or created | yes | `get_goal` returned none; created active goal for sync PR observability |
+| Source of truth read before edits | yes | read `tooling/scripts/release-branch-prs.mjs`, `tooling/scripts/release-workflow.test.mjs`, `.github/workflows/release.yml` sync job |
+| Tracker comments and attachments read | no | chat-only task; no tracker |
+| Video transcript evidence required | no | no video evidence |
+| `docs/solutions` checked for non-trivial existing-code work | yes | scoped `rg` and read release docs solution; no main->next resolver audit runbook exists |
+| TDD decision before behavior change or bug fix | yes | add unit tests with the implementation |
+| Branch decision for code-changing task | yes | continue current checkout; no PR requested |
+| Release artifact decision | yes | N/A: tooling/workflow change only, no package release changeset |
+| Browser tool decision for browser surface | no | release automation only |
+| PR expectation decision | yes | no PR requested in this turn |
+| Tracker sync expectation decision | no | no tracker |
+| Output budget strategy recorded | yes | scoped reads and capped outputs recorded above |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `node --test tooling/scripts/release-workflow.test.mjs`; `pnpm lint:fix`; real #31 verifier run |
+| Bug reproduced before fix | no | Record failing test/repro or N/A with reason | N/A: hardening task, not a bug repro |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync --commit FETCH_HEAD` passed against felix PR #31 |
+| TypeScript or typed config changed | no | Run relevant typecheck | N/A: JavaScript workflow tooling and YAML only |
+| Package exports or file layout changed | no | Run `pnpm brl` before final verification and keep generated barrel updates | N/A: no package exports or file layout changed |
+| Package manifests, lockfile, or install graph changed | no | Run `pnpm install` and relevant package checks | N/A: no manifests or lockfile changed |
+| Agent rules or skills changed | no | Run `pnpm install` and verify generated skill sync | N/A: no `.agents` source changed |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | all commands ran in `/Users/felixfeng/Desktop/repos/plate` |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: release automation only |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no browser surface |
+| CI-controlled template output changed | no | Restore generated template output or record why it is intentionally kept | N/A: no template output changed |
+| Package behavior or public API changed | no | Add a changeset or record why no changeset applies | N/A: no package runtime/API change |
+| Registry-only component work changed | no | Update `tooling/data/plate-ui-changelog.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, or record N/A | N/A: not registry work |
+| Docs or content changed | no | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | N/A: only goal plan bookkeeping changed |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | failure mode: bad resolver hides metadata damage; proof: unit tests plus real #31 verifier; boundary: release PR tooling and sync workflow |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: GitHub workflow/release script, not agent tooling |
+| Local install corruption suspected | no | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | N/A: no install-corruption signal |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | `.agents/skills/autoreview/scripts/autoreview --mode local` blocked by Codex config `service_tier=priority`; manual review found and fixed conflict-marker regex gap |
+| PR create or update | no | Run `check` before PR work and sync PR body to the task-style final handoff | N/A: no PR requested |
+| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR created |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR/browser proof image |
+| Tracker sync-back | no | Post concise issue/Linear sync after PR exists, or record N/A/blocker | N/A: no tracker |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | final handoff fields filled below |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | scoped `sed`, `rg`, and capped command outputs only |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-sync-pr-observability.md` | passed |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | source files, workflow, relevant solution doc read | implementation |
+| Implementation | complete | release script report/verifier plus workflow added | verification |
+| Verification | complete | target test, lint, real #31 verifier passed | closeout |
+| PR / tracker sync | complete | N/A: no PR/tracker requested | final response |
+| Closeout | complete | plan finalized for checker | final response |
+
+Findings:
+- Existing resolver keeps next package versions, keeps `.changeset/pre.json` from next, and merges stable changelog sections deterministically.
+- Better Auth keeps main -> next conflict resolution manual; Plate is intentionally stricter because package metadata conflicts are predictable and testable.
+
+Decisions and tradeoffs:
+- Keep automatic release metadata resolution, but make it auditable in the PR body and re-check it in CI.
+- Do not add comments yet; PR body is less noisy and gets updated with the branch.
+
+Implementation notes:
+- None yet.
+
+Review fixes:
+- Manual review found conflict marker detection missed bare `=======`; fixed regex and added regression test.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- `node --test tooling/scripts/release-workflow.test.mjs`: 17 tests passed.
+- `pnpm lint:fix`: passed, no fixes applied after final code.
+- `git fetch felix pull/31/head && node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync --commit FETCH_HEAD`: passed; reported `packages/basic-nodes/CHANGELOG.md` inserted `53.1.9` and `packages/basic-nodes/package.json` kept `53.2.0-beta.0`.
+- `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-sync-pr-observability.md`: passed.
+
+Final handoff contract:
+- PR line: N/A, no PR requested.
+- Issue / tracker line: N/A, no tracker.
+- Confidence line: high after tests plus real #31 proof.
+- Flow table:
+  - Reproduced: N/A hardening task, browser N/A
+  - Verified: tests passed, browser N/A
+- Browser check: N/A, release automation only.
+- Outcome: sync PRs now expose resolver decisions and get a dedicated metadata verification check.
+- Caveat: autoreview helper blocked by local Codex config; manual review performed and caught one real issue.
+- Design:
+  - Chosen boundary: `release-branch-prs.mjs` owns resolver decisions; workflow owns PR-time check.
+  - Why not quick patch: comments without verification would still require blind trust.
+  - Why not broader change: no need to replace release flow or make Better Auth-style manual conflicts the default.
+- Verified: target test, lint, and real #31 verifier pass.
+- PR body verified: N/A, no PR created; helper body covered by unit test.
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: N/A.
+- Issue / tracker: N/A.
+- Browser proof: N/A.
+- Caveats: autoreview helper blocked by local Codex config; no browser surface.
+
+Timeline:
+- 2026-06-16T03:38:22.532Z Task goal plan created.
+- 2026-06-16T03:42:00Z Source read complete; implementation started.
+- 2026-06-16T04:02:00Z Implementation, tests, lint, real #31 verifier, and plan closeout completed.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Implementation, verification, PR/tracker sync, closeout |
+| What is the goal? | Make sync PR resolver decisions visible and independently verified |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- The package manifest verifier intentionally rejects third-state manifest merges. That is conservative; if a future sync genuinely needs to combine unrelated manifest field changes from both parents, the check should fail and force a human resolution instead of silently guessing.

--- a/tooling/scripts/release-branch-prs.mjs
+++ b/tooling/scripts/release-branch-prs.mjs
@@ -12,6 +12,8 @@ const newlinePattern = /\r?\n/;
 const shellSafeArgPattern = /^[A-Za-z0-9_./:=@-]+$/;
 const stableVersionPattern = /^\d+\.\d+\.\d+$/;
 const semverPattern = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
+const conflictMarkerPattern = /^(?:<<<<<<<|=======|>>>>>>>)(?:\s|$)/m;
+const whitespacePattern = /\s+/;
 
 export function getStableVersion(version) {
   const stableVersion = String(version ?? '').split('-')[0];
@@ -40,21 +42,93 @@ export function buildPromotePullRequest({ version }) {
   };
 }
 
-export function buildMainToNextSyncPullRequest() {
+export function buildMainToNextSyncPullRequest({ resolutionReport } = {}) {
+  const body = [
+    'Brings stable fixes from `main` into the beta branch.',
+    '',
+    'This PR is prepared from `next` by merging `main` into `sync/main-to-next` first. Release metadata conflicts are resolved automatically before the PR opens.',
+    '',
+    '**Merge with `Create a merge commit`**. Do not squash or rebase; this preserves the stable fix commits before the next beta cut.',
+    '',
+    'If this PR still has conflicts, they are real source conflicts. Package versions, beta pre-release state, and changelog section ordering are handled by automation.',
+  ];
+
+  if (resolutionReport) {
+    body.push('', formatMainToNextSyncResolutionReport(resolutionReport));
+  }
+
   return {
     base: 'next',
-    body: [
-      'Brings stable fixes from `main` into the beta branch.',
-      '',
-      'This PR is prepared from `next` by merging `main` into `sync/main-to-next` first. Release metadata conflicts are resolved automatically before the PR opens.',
-      '',
-      '**Merge with `Create a merge commit`**. Do not squash or rebase; this preserves the stable fix commits before the next beta cut.',
-      '',
-      'If this PR still has conflicts, they are real source conflicts. Package versions, beta pre-release state, and changelog section ordering are handled by automation.',
-    ].join('\n'),
+    body: body.join('\n'),
     head: mainToNextSyncBranch,
     title: 'chore: sync main to next [skip release]',
   };
+}
+
+function formatVersionList(versions) {
+  return versions.map((version) => `\`${version}\``).join(', ');
+}
+
+export function formatMainToNextSyncResolutionReport(report) {
+  const decisions = [];
+
+  for (const item of report.packageManifests ?? []) {
+    const name = item.packageName ? ` (${item.packageName})` : '';
+
+    decisions.push(
+      `- \`${item.file}\`${name}: kept next/beta version \`${item.keptVersion}\` over main/stable \`${item.mainVersion}\`.`
+    );
+  }
+
+  for (const item of report.preJsonFiles ?? []) {
+    decisions.push(`- \`${item.file}\`: kept next beta pre-release state.`);
+  }
+
+  for (const item of report.changelogs ?? []) {
+    const pieces = [];
+
+    if (item.insertedStableVersions.length > 0) {
+      pieces.push(
+        `inserted stable sections ${formatVersionList(item.insertedStableVersions)}`
+      );
+    }
+
+    if (item.refreshedStableVersions.length > 0) {
+      pieces.push(
+        `refreshed stable sections ${formatVersionList(item.refreshedStableVersions)} from main`
+      );
+    }
+
+    decisions.push(
+      `- \`${item.file}\`: ${pieces.length > 0 ? pieces.join('; ') : 'kept existing changelog order'}.`
+    );
+  }
+
+  if (decisions.length === 0) {
+    decisions.push(
+      '- No release metadata conflicts required automatic resolution.'
+    );
+  }
+
+  const checks =
+    report.checks && report.checks.length > 0
+      ? report.checks
+      : [
+          'no conflict markers in resolved release metadata',
+          'next/beta package versions preserved',
+          'stable changelog sections inserted deterministically',
+          'package manifests checked for unexpected third-state edits',
+        ];
+
+  return [
+    '## Automated release metadata resolution',
+    '',
+    ...decisions,
+    '',
+    '### Verification',
+    '',
+    ...checks.map((check) => `- ${check}`),
+  ].join('\n');
 }
 
 function run(command, args, { allowFailure = false, capture = false } = {}) {
@@ -110,6 +184,20 @@ function runGit(
   return run('git', args, { allowFailure, capture });
 }
 
+function runGitProcess(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
 function requireRepository(env) {
   const repository = env.GITHUB_REPOSITORY;
 
@@ -131,6 +219,16 @@ function writeRepoFile(file, content) {
   );
 }
 
+function normalizeText(content) {
+  return `${String(content).replace(/\r\n/g, '\n').trimEnd()}\n`;
+}
+
+function assertNoConflictMarkers(file, content) {
+  if (conflictMarkerPattern.test(content)) {
+    throw new Error(`${file} still contains merge conflict markers.`);
+  }
+}
+
 function getUnmergedFiles() {
   const output = runGit(['diff', '--name-only', '--diff-filter=U'], {
     capture: true,
@@ -145,6 +243,14 @@ function isPackageManifest(file) {
 
 function isChangelog(file) {
   return file.endsWith('/CHANGELOG.md') || file === 'CHANGELOG.md';
+}
+
+function isMainToNextMetadataFile(file) {
+  return (
+    isPackageManifest(file) ||
+    isChangelog(file) ||
+    file === '.changeset/pre.json'
+  );
 }
 
 function normalizePackageForVersionOnlyCompare(packageJson) {
@@ -175,6 +281,18 @@ export function resolvePackageManifestForMainToNextSync({ ours, theirs }) {
   }
 
   return `${JSON.stringify(oursJson, null, 2)}\n`;
+}
+
+function recordPackageManifestResolution({ file, ours, report, theirs }) {
+  const oursJson = JSON.parse(ours);
+  const theirsJson = JSON.parse(theirs);
+
+  report.packageManifests.push({
+    file,
+    keptVersion: oursJson.version,
+    mainVersion: theirsJson.version,
+    packageName: oursJson.name,
+  });
 }
 
 function parseSemver(version) {
@@ -249,7 +367,7 @@ function collectStableChangelogInsertions({ oursVersions, theirsSections }) {
   };
 }
 
-export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
+export function getMainToNextChangelogResolution({ ours, theirs }) {
   const oursChangelog = parseChangelog(ours);
   const theirsChangelog = parseChangelog(theirs);
   const oursVersions = new Set(
@@ -263,6 +381,8 @@ export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
     theirsSections: theirsChangelog.sections,
   });
   const sections = [];
+  const insertedStableVersions = [];
+  const refreshedStableVersions = [];
 
   for (const section of oursChangelog.sections) {
     const sectionsToInsert = stableInsertions.sectionsByAnchorVersion.get(
@@ -272,6 +392,17 @@ export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
 
     if (sectionsToInsert) {
       sections.push(...sectionsToInsert);
+      insertedStableVersions.push(
+        ...sectionsToInsert.map((sectionToInsert) => sectionToInsert.version)
+      );
+    }
+
+    if (
+      theirsSection &&
+      isStableChangelogSection(section) &&
+      theirsSection.raw !== section.raw
+    ) {
+      refreshedStableVersions.push(section.version);
     }
 
     sections.push(
@@ -282,39 +413,70 @@ export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
   }
 
   sections.push(...stableInsertions.trailingSections);
+  insertedStableVersions.push(
+    ...stableInsertions.trailingSections.map((section) => section.version)
+  );
 
   const header = oursChangelog.header || theirsChangelog.header;
 
-  return `${header}\n\n${sections.map((section) => section.raw).join('\n\n')}\n`;
+  return {
+    content: `${header}\n\n${sections.map((section) => section.raw).join('\n\n')}\n`,
+    insertedStableVersions,
+    refreshedStableVersions,
+  };
 }
 
-function resolveMainToNextMetadataConflict(file) {
+export function mergeChangelogsForMainToNextSync({ ours, theirs }) {
+  return getMainToNextChangelogResolution({ ours, theirs }).content;
+}
+
+function createMainToNextResolutionReport() {
+  return {
+    changelogs: [],
+    checks: [
+      'no conflict markers in resolved release metadata',
+      'next/beta package versions preserved',
+      'stable changelog sections inserted deterministically',
+      'package manifests checked for unexpected third-state edits',
+    ],
+    packageManifests: [],
+    preJsonFiles: [],
+  };
+}
+
+function resolveMainToNextMetadataConflict(file, report) {
   if (isPackageManifest(file)) {
+    const ours = readGitStage(2, file);
+    const theirs = readGitStage(3, file);
+
     writeRepoFile(
       file,
-      resolvePackageManifestForMainToNextSync({
-        ours: readGitStage(2, file),
-        theirs: readGitStage(3, file),
-      })
+      resolvePackageManifestForMainToNextSync({ ours, theirs })
     );
+    recordPackageManifestResolution({ file, ours, report, theirs });
     runGit(['add', file]);
     return true;
   }
 
   if (file === '.changeset/pre.json') {
     writeRepoFile(file, readGitStage(2, file));
+    report.preJsonFiles.push({ file });
     runGit(['add', file]);
     return true;
   }
 
   if (isChangelog(file)) {
-    writeRepoFile(
+    const resolution = getMainToNextChangelogResolution({
+      ours: readGitStage(2, file),
+      theirs: readGitStage(3, file),
+    });
+
+    writeRepoFile(file, resolution.content);
+    report.changelogs.push({
       file,
-      mergeChangelogsForMainToNextSync({
-        ours: readGitStage(2, file),
-        theirs: readGitStage(3, file),
-      })
-    );
+      insertedStableVersions: resolution.insertedStableVersions,
+      refreshedStableVersions: resolution.refreshedStableVersions,
+    });
     runGit(['add', file]);
     return true;
   }
@@ -323,12 +485,13 @@ function resolveMainToNextMetadataConflict(file) {
 }
 
 function resolveMainToNextMetadataConflicts() {
+  const report = createMainToNextResolutionReport();
   const unmergedFiles = getUnmergedFiles();
   const unresolvedFiles = [];
 
   for (const file of unmergedFiles) {
     try {
-      if (!resolveMainToNextMetadataConflict(file)) {
+      if (!resolveMainToNextMetadataConflict(file, report)) {
         unresolvedFiles.push(file);
       }
     } catch (error) {
@@ -355,6 +518,175 @@ function resolveMainToNextMetadataConflicts() {
       ].join('\n')
     );
   }
+
+  return report;
+}
+
+function getGitCommitParents(commit) {
+  const line = runGit(['rev-list', '--parents', '-n', '1', commit], {
+    capture: true,
+  });
+  const [resolvedCommit, ...parents] = line
+    .split(whitespacePattern)
+    .filter(Boolean);
+
+  return { parents, resolvedCommit };
+}
+
+function listGitDiffFiles(from, to) {
+  const output = runGit(['diff', '--name-only', from, to], { capture: true });
+
+  return output.split(newlinePattern).filter(Boolean);
+}
+
+function tryReadGitCommitFile(commit, file) {
+  const result = runGitProcess(['show', `${commit}:${file}`]);
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  return result.stdout;
+}
+
+function isPrereleaseVersion(version) {
+  return !!parseSemver(version)?.pre;
+}
+
+export function verifyMainToNextResolvedFile({ file, ours, resolved, theirs }) {
+  assertNoConflictMarkers(file, resolved);
+
+  if (isPackageManifest(file)) {
+    const oursJson = JSON.parse(ours);
+    const resolvedJson = JSON.parse(resolved);
+    const theirsJson = JSON.parse(theirs);
+
+    if (
+      isPrereleaseVersion(oursJson.version) &&
+      resolvedJson.version !== oursJson.version
+    ) {
+      throw new Error(
+        `${file} downgraded next/beta version ${oursJson.version} to ${resolvedJson.version}.`
+      );
+    }
+
+    const normalizedResolved =
+      normalizePackageForVersionOnlyCompare(resolvedJson);
+    const normalizedOurs = normalizePackageForVersionOnlyCompare(oursJson);
+    const normalizedTheirs = normalizePackageForVersionOnlyCompare(theirsJson);
+
+    if (
+      normalizedResolved !== normalizedOurs &&
+      normalizedResolved !== normalizedTheirs
+    ) {
+      throw new Error(
+        `${file} contains package manifest fields that match neither next nor main.`
+      );
+    }
+
+    return {
+      file,
+      message: `kept package version ${resolvedJson.version}`,
+      type: 'package-manifest',
+    };
+  }
+
+  if (file === '.changeset/pre.json') {
+    if (normalizeText(resolved) !== normalizeText(ours)) {
+      throw new Error(`${file} did not keep next beta pre-release state.`);
+    }
+
+    return {
+      file,
+      message: 'kept next beta pre-release state',
+      type: 'pre-json',
+    };
+  }
+
+  if (isChangelog(file)) {
+    const expected = getMainToNextChangelogResolution({ ours, theirs });
+
+    if (normalizeText(resolved) !== normalizeText(expected.content)) {
+      throw new Error(
+        `${file} does not match the deterministic main-to-next changelog merge.`
+      );
+    }
+
+    return {
+      file,
+      insertedStableVersions: expected.insertedStableVersions,
+      message:
+        expected.insertedStableVersions.length > 0
+          ? `inserted stable sections ${expected.insertedStableVersions.join(', ')}`
+          : 'verified changelog order',
+      type: 'changelog',
+    };
+  }
+
+  throw new Error(`${file} is not a supported main-to-next metadata file.`);
+}
+
+export function verifyMainToNextSyncMergeCommit({ commit = 'HEAD' } = {}) {
+  const { parents, resolvedCommit } = getGitCommitParents(commit);
+
+  if (parents.length < 2) {
+    throw new Error(
+      `${resolvedCommit} is not a merge commit; sync/main-to-next must preserve the main merge parent.`
+    );
+  }
+
+  const [nextParent, mainParent] = parents;
+  const files = [
+    ...new Set(
+      [
+        ...listGitDiffFiles(nextParent, mainParent),
+        ...listGitDiffFiles(nextParent, resolvedCommit),
+        ...listGitDiffFiles(mainParent, resolvedCommit),
+      ].filter(isMainToNextMetadataFile)
+    ),
+  ].sort();
+  const results = [];
+
+  for (const file of files) {
+    const ours = tryReadGitCommitFile(nextParent, file);
+    const theirs = tryReadGitCommitFile(mainParent, file);
+    const resolved = tryReadGitCommitFile(resolvedCommit, file);
+
+    if (resolved) {
+      assertNoConflictMarkers(file, resolved);
+    }
+
+    if (!ours || !theirs || !resolved) {
+      continue;
+    }
+
+    results.push(
+      verifyMainToNextResolvedFile({
+        file,
+        ours,
+        resolved,
+        theirs,
+      })
+    );
+  }
+
+  console.log('Main -> next sync metadata verification passed.');
+
+  if (results.length === 0) {
+    console.log('- No shared release metadata files needed verification.');
+  } else {
+    for (const result of results) {
+      console.log(`- ${result.file}: ${result.message}`);
+    }
+  }
+
+  return {
+    files,
+    mainParent,
+    nextParent,
+    resolvedCommit,
+    results,
+  };
 }
 
 export function createOrUpdatePromotePullRequest({
@@ -430,7 +762,6 @@ export function createOrUpdateMainToNextSyncPullRequest({
   env = process.env,
 } = {}) {
   const repository = requireRepository(env);
-  const pullRequest = buildMainToNextSyncPullRequest();
 
   runGit(['fetch', 'origin', 'main', 'next'], { dryRun });
 
@@ -467,9 +798,10 @@ export function createOrUpdateMainToNextSyncPullRequest({
     dryRun,
   });
 
-  if (!dryRun) {
-    resolveMainToNextMetadataConflicts();
-  }
+  const resolutionReport = dryRun
+    ? createMainToNextResolutionReport()
+    : resolveMainToNextMetadataConflicts();
+  const pullRequest = buildMainToNextSyncPullRequest({ resolutionReport });
 
   runGit(
     [
@@ -581,9 +913,13 @@ if (isMainModule()) {
       });
     } else if (command === 'sync-main-to-next') {
       createOrUpdateMainToNextSyncPullRequest({ dryRun });
+    } else if (command === 'verify-main-to-next-sync') {
+      verifyMainToNextSyncMergeCommit({
+        commit: readOption(args, '--commit') ?? 'HEAD',
+      });
     } else {
       throw new Error(
-        'Usage: release-branch-prs.mjs <promote --version x.y.z | sync-main-to-next> [--dry-run]'
+        'Usage: release-branch-prs.mjs <promote --version x.y.z | sync-main-to-next | verify-main-to-next-sync> [--dry-run]'
       );
     }
   } catch (error) {

--- a/tooling/scripts/release-workflow.test.mjs
+++ b/tooling/scripts/release-workflow.test.mjs
@@ -6,10 +6,13 @@ import { validateBetaPreState } from './guard-beta-pre-release.mjs';
 import {
   buildMainToNextSyncPullRequest,
   buildPromotePullRequest,
+  formatMainToNextSyncResolutionReport,
+  getMainToNextChangelogResolution,
   getStableVersion,
   mainToNextSyncBranch,
   mergeChangelogsForMainToNextSync,
   resolvePackageManifestForMainToNextSync,
+  verifyMainToNextResolvedFile,
 } from './release-branch-prs.mjs';
 import {
   getReleasePlan,
@@ -31,6 +34,10 @@ const autoRetargetWorkflowPath = new URL(
 );
 const verifyChangesetsWorkflowPath = new URL(
   '../../.github/workflows/verify-changesets.yml',
+  import.meta.url
+);
+const verifyMainToNextSyncWorkflowPath = new URL(
+  '../../.github/workflows/verify-main-to-next-sync.yml',
   import.meta.url
 );
 const packageJsonPath = new URL('../../package.json', import.meta.url);
@@ -186,6 +193,42 @@ test('release branch PR helpers build promote and sync PRs', () => {
   assert.match(syncPullRequest.body, /Release metadata conflicts/);
 });
 
+test('main to next sync PR reports automated release metadata resolution', () => {
+  const report = {
+    changelogs: [
+      {
+        file: 'packages/core/CHANGELOG.md',
+        insertedStableVersions: ['53.1.8'],
+        refreshedStableVersions: ['53.1.2'],
+      },
+    ],
+    checks: ['verified by test'],
+    packageManifests: [
+      {
+        file: 'packages/core/package.json',
+        keptVersion: '54.0.0-beta.1',
+        mainVersion: '53.1.8',
+        packageName: '@platejs/core',
+      },
+    ],
+    preJsonFiles: [{ file: '.changeset/pre.json' }],
+  };
+  const body = buildMainToNextSyncPullRequest({
+    resolutionReport: report,
+  }).body;
+  const formatted = formatMainToNextSyncResolutionReport(report);
+
+  assert.match(body, /Automated release metadata resolution/);
+  assert.match(
+    body,
+    /kept next\/beta version `54\.0\.0-beta\.1` over main\/stable `53\.1\.8`/
+  );
+  assert.match(body, /inserted stable sections `53\.1\.8`/);
+  assert.match(body, /refreshed stable sections `53\.1\.2` from main/);
+  assert.match(body, /kept next beta pre-release state/);
+  assert.match(formatted, /verified by test/);
+});
+
 test('main to next sync keeps beta package versions', () => {
   const resolved = resolvePackageManifestForMainToNextSync({
     ours: JSON.stringify({
@@ -213,6 +256,153 @@ test('main to next sync keeps beta package versions', () => {
           '{"name":"@platejs/core","description":"changed","version":"53.1.8"}',
       }),
     /changed fields other than version/
+  );
+});
+
+test('main to next sync verifier checks package, pre-state, and changelog output', () => {
+  const nextPackage = JSON.stringify({
+    description: 'test',
+    name: '@platejs/core',
+    version: '54.0.0-beta.1',
+  });
+  const mainPackage = JSON.stringify({
+    description: 'test',
+    name: '@platejs/core',
+    version: '53.1.8',
+  });
+
+  assert.deepEqual(
+    verifyMainToNextResolvedFile({
+      file: 'packages/core/package.json',
+      ours: nextPackage,
+      resolved: nextPackage,
+      theirs: mainPackage,
+    }),
+    {
+      file: 'packages/core/package.json',
+      message: 'kept package version 54.0.0-beta.1',
+      type: 'package-manifest',
+    }
+  );
+  assert.throws(
+    () =>
+      verifyMainToNextResolvedFile({
+        file: 'packages/core/package.json',
+        ours: nextPackage,
+        resolved: mainPackage,
+        theirs: mainPackage,
+      }),
+    /downgraded next\/beta version/
+  );
+  assert.throws(
+    () =>
+      verifyMainToNextResolvedFile({
+        file: 'packages/core/package.json',
+        ours: nextPackage,
+        resolved: JSON.stringify({
+          description: 'third state',
+          name: '@platejs/core',
+          version: '54.0.0-beta.1',
+        }),
+        theirs: mainPackage,
+      }),
+    /match neither next nor main/
+  );
+
+  assert.deepEqual(
+    verifyMainToNextResolvedFile({
+      file: '.changeset/pre.json',
+      ours: '{"mode":"pre","tag":"beta"}\n',
+      resolved: '{"mode":"pre","tag":"beta"}\n',
+      theirs: '{}\n',
+    }),
+    {
+      file: '.changeset/pre.json',
+      message: 'kept next beta pre-release state',
+      type: 'pre-json',
+    }
+  );
+  assert.throws(
+    () =>
+      verifyMainToNextResolvedFile({
+        file: '.changeset/pre.json',
+        ours: '{"mode":"pre","tag":"beta"}\n',
+        resolved: '{}\n',
+        theirs: '{}\n',
+      }),
+    /did not keep next beta pre-release state/
+  );
+
+  const oursChangelog = [
+    '# @platejs/core',
+    '',
+    '## 54.0.0-beta.1',
+    '',
+    '### Minor Changes',
+    '',
+    '- Beta minor.',
+    '',
+    '## 53.1.2',
+    '',
+    '### Patch Changes',
+    '',
+    '- Existing stable patch.',
+    '',
+  ].join('\n');
+  const theirsChangelog = [
+    '# @platejs/core',
+    '',
+    '## 53.1.8',
+    '',
+    '### Patch Changes',
+    '',
+    '- Main patch.',
+    '',
+    '## 53.1.2',
+    '',
+    '### Patch Changes',
+    '',
+    '- Existing stable patch from main.',
+    '',
+  ].join('\n');
+  const changelogResolution = getMainToNextChangelogResolution({
+    ours: oursChangelog,
+    theirs: theirsChangelog,
+  });
+
+  assert.deepEqual(
+    verifyMainToNextResolvedFile({
+      file: 'packages/core/CHANGELOG.md',
+      ours: oursChangelog,
+      resolved: changelogResolution.content,
+      theirs: theirsChangelog,
+    }),
+    {
+      file: 'packages/core/CHANGELOG.md',
+      insertedStableVersions: ['53.1.8'],
+      message: 'inserted stable sections 53.1.8',
+      type: 'changelog',
+    }
+  );
+  assert.throws(
+    () =>
+      verifyMainToNextResolvedFile({
+        file: 'packages/core/CHANGELOG.md',
+        ours: oursChangelog,
+        resolved: oursChangelog,
+        theirs: theirsChangelog,
+      }),
+    /does not match the deterministic main-to-next changelog merge/
+  );
+  assert.throws(
+    () =>
+      verifyMainToNextResolvedFile({
+        file: 'packages/core/CHANGELOG.md',
+        ours: oursChangelog,
+        resolved: `${changelogResolution.content}\n=======\n`,
+        theirs: theirsChangelog,
+      }),
+    /still contains merge conflict markers/
   );
 });
 
@@ -495,6 +685,27 @@ test('verify changesets workflow blocks non-patch releases on main', async () =>
     /releaseType === 'minor' \|\| releaseType === 'major'/
   );
   assert.match(workflow, /Only patch bumps are allowed/);
+});
+
+test('verify main-to-next sync workflow checks only sync PR metadata', async () => {
+  const workflow = await readFile(verifyMainToNextSyncWorkflowPath, 'utf8');
+
+  assert.match(workflow, /name:\s*Verify main-to-next sync/);
+  assert.match(workflow, /pull_request:/);
+  assert.match(workflow, /branches:\s*\n\s*-\s*next/);
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.head\.ref == 'sync\/main-to-next'/
+  );
+  assert.match(
+    workflow,
+    /ref:\s*\$\{\{ github\.event\.pull_request\.head\.sha \}\}/
+  );
+  assert.match(workflow, /fetch-depth:\s*0/);
+  assert.match(
+    workflow,
+    /node tooling\/scripts\/release-branch-prs\.mjs verify-main-to-next-sync/
+  );
 });
 
 test('package scripts expose CI version and release commands only', async () => {


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | 🟢 `pnpm check`; 🟢 real #31 sync verifier | ➖ N/A |

**✅ Outcome**

Adds an auditable main -> next sync path: sync PR bodies show automatic release metadata decisions, and `sync/main-to-next` PRs get a dedicated metadata verification workflow.

**⚠️ Caveat**

The verifier intentionally fails conservative cases where a package manifest resolves to a third state that is neither next nor main. That is the right failure mode for release metadata. Local pre-commit printed a missing `lefthook` warning, but the commit succeeded and `pnpm check` passed.

**🏗️ Design**

`tooling/scripts/release-branch-prs.mjs` owns resolver decisions and the verifier. `.github/workflows/verify-main-to-next-sync.yml` runs only for `sync/main-to-next` PRs into `next`, so normal contributor PRs are untouched.

**🧪 Verified**

- `pnpm check`
- `node --test tooling/scripts/release-workflow.test.mjs`
- `node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync --commit FETCH_HEAD` against felix PR #31, confirming `packages/basic-nodes/CHANGELOG.md` inserted `53.1.9` and package version stayed `53.2.0-beta.0`
