### PR TITLE
fix: scope main-to-next metadata verification

### DIFF
--- a/tooling/scripts/release-branch-prs.mjs
+++ b/tooling/scripts/release-branch-prs.mjs
@@ -539,6 +539,23 @@ function listGitDiffFiles(from, to) {
   return output.split(newlinePattern).filter(Boolean);
 }
 
+function getGitMergeBase(left, right) {
+  return runGit(['merge-base', left, right], { capture: true });
+}
+
+export function getMainToNextSyncMetadataFiles({
+  mainChangedFiles,
+  resolvedChangedFiles,
+}) {
+  return [
+    ...new Set(
+      [...mainChangedFiles, ...resolvedChangedFiles].filter(
+        isMainToNextMetadataFile
+      )
+    ),
+  ].sort();
+}
+
 function tryReadGitCommitFile(commit, file) {
   const result = runGitProcess(['show', `${commit}:${file}`]);
 
@@ -636,15 +653,11 @@ export function verifyMainToNextSyncMergeCommit({ commit = 'HEAD' } = {}) {
   }
 
   const [nextParent, mainParent] = parents;
-  const files = [
-    ...new Set(
-      [
-        ...listGitDiffFiles(nextParent, mainParent),
-        ...listGitDiffFiles(nextParent, resolvedCommit),
-        ...listGitDiffFiles(mainParent, resolvedCommit),
-      ].filter(isMainToNextMetadataFile)
-    ),
-  ].sort();
+  const mergeBase = getGitMergeBase(nextParent, mainParent);
+  const files = getMainToNextSyncMetadataFiles({
+    mainChangedFiles: listGitDiffFiles(mergeBase, mainParent),
+    resolvedChangedFiles: listGitDiffFiles(nextParent, resolvedCommit),
+  });
   const results = [];
 
   for (const file of files) {
@@ -683,6 +696,7 @@ export function verifyMainToNextSyncMergeCommit({ commit = 'HEAD' } = {}) {
   return {
     files,
     mainParent,
+    mergeBase,
     nextParent,
     resolvedCommit,
     results,

--- a/tooling/scripts/release-workflow.test.mjs
+++ b/tooling/scripts/release-workflow.test.mjs
@@ -8,6 +8,7 @@ import {
   buildPromotePullRequest,
   formatMainToNextSyncResolutionReport,
   getMainToNextChangelogResolution,
+  getMainToNextSyncMetadataFiles,
   getStableVersion,
   mainToNextSyncBranch,
   mergeChangelogsForMainToNextSync,
@@ -403,6 +404,33 @@ test('main to next sync verifier checks package, pre-state, and changelog output
         theirs: theirsChangelog,
       }),
     /still contains merge conflict markers/
+  );
+});
+
+test('main to next sync verifier scopes metadata files to synced changes', () => {
+  assert.deepEqual(
+    getMainToNextSyncMetadataFiles({
+      mainChangedFiles: [
+        '.github/workflows/verify-main-to-next-sync.yml',
+        'tooling/scripts/release-branch-prs.mjs',
+      ],
+      resolvedChangedFiles: [],
+    }),
+    []
+  );
+  assert.deepEqual(
+    getMainToNextSyncMetadataFiles({
+      mainChangedFiles: [
+        'packages/basic-nodes/CHANGELOG.md',
+        'packages/basic-nodes/package.json',
+      ],
+      resolvedChangedFiles: ['packages/core/CHANGELOG.md'],
+    }),
+    [
+      'packages/basic-nodes/CHANGELOG.md',
+      'packages/basic-nodes/package.json',
+      'packages/core/CHANGELOG.md',
+    ]
   );
 });
 


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 #35 verifier failed locally on historical `packages/plate/CHANGELOG.md` divergence | ➖ N/A |
| Verified | 🟢 `pnpm check`; 🟢 #35 verifier passes; 🟢 #31 verifier still checks package/changelog metadata | ➖ N/A |

**✅ Outcome**

Scopes main -> next metadata verification to metadata files changed by the synced main commits plus metadata files actually changed in the merge result. This avoids false positives from old `main`/`next` changelog divergence.

**⚠️ Caveat**

Local pre-commit still prints the existing missing `lefthook` warning, but commit succeeds and `pnpm check` passes.

**🏗️ Design**

The verifier now uses `merge-base(nextParent, mainParent)..mainParent` for synced main-side metadata, plus `nextParent..resolvedCommit` for final merge-result metadata. That keeps package version protection for files resolved as “ours” while avoiding unrelated historical branch drift.

**🧪 Verified**

- `node --test tooling/scripts/release-workflow.test.mjs`
- `node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync --commit FETCH_HEAD` against felix PR #35
- `node tooling/scripts/release-branch-prs.mjs verify-main-to-next-sync --commit FETCH_HEAD` against felix PR #31
- `pnpm check`
