### PR TITLE
test: add core patch release flow changeset

### DIFF
--- a/.changeset/test-core-patch-post-sync.md
+++ b/.changeset/test-core-patch-post-sync.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Test post-verifier main-to-next sync patch flow.


### PR DESCRIPTION
🐛 Fixes ➖ N/A
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | ➖ N/A | ➖ N/A |
| Verified | 🟢 `pnpm check` | ➖ N/A |

**✅ Outcome**

Adds a single `@platejs/core` patch changeset to test the main patch release flow after the sync verifier fix.

**⚠️ Caveat**

This is an intentional test changeset. Local pre-commit still prints the existing missing `lefthook` warning, but commit succeeds and `pnpm check` passes.

**🏗️ Design**

One package, one changeset, patch only. No source changes.

**🧪 Verified**

- `pnpm check`
